### PR TITLE
Use alpine 3.8 to support PostgreSQL 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.8
 RUN \
     apk add --no-cache -v postgresql python3 less groff \
     && pip3 install awscli \


### PR DESCRIPTION
I can use PostgreSQL 9.6 only because the current image on Docker Hub is based on Alpine 3.5. The image was built long time ago although there is no version tag of Alpine in Dockerfile.

This PR is clarifying version tag of Alpine to support PostgreSQL 10. It would be better if image tags were created separately for each PostgreSQL version. (maybe 9, 10, 11)

ref: https://pkgs.alpinelinux.org/packages?name=postgresql&branch=v3.8